### PR TITLE
Export `ApiValidityBound` constructors from `Cardano.Wallet.Api.Types`

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -156,7 +156,7 @@ module Cardano.Wallet.Api.Types
     , ApiStakeKeyIndex (..)
     , ApiPaymentDestination (..)
     , ApiValidityInterval (..)
-    , ApiValidityBound
+    , ApiValidityBound (..)
     , PostMintBurnAssetData(..)
     , ApiBalanceTransactionPostData (..)
     , ApiExternalInput (..)


### PR DESCRIPTION
Fixes #3112 (please refer to that issue for the rationale behind this tiny change)